### PR TITLE
Refactor paths to work cross-platform

### DIFF
--- a/Dungeon.Monogame/Dungeon.Monogame.csproj
+++ b/Dungeon.Monogame/Dungeon.Monogame.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <StartupObject />
     <Configurations>Debug;Release;CompileDatabase</Configurations>
-    <RestoreFallbackFolders>clear</RestoreFallbackFolders>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;Core;WINDOWS;monogameRuntime;DisableSound;</DefineConstants>

--- a/Dungeon/Data/Store.Init.cs
+++ b/Dungeon/Data/Store.Init.cs
@@ -48,7 +48,7 @@ namespace Dungeon
         private static List<LocalizedString> CompileDatabase()
         {
             var strings = new List<LocalizedString>();
-            using (var db = new LiteDatabase($@"{MainPath}\Data.db"))
+            using (var db = new LiteDatabase(Path.Combine(MainPath, "Data.db")))
             {
                 foreach (var data in JsonFiles())
                 {
@@ -80,7 +80,7 @@ namespace Dungeon
                 }
             }
 
-            using (var buildDb = new LiteDatabase($@"{MainPath}\DataManifest.dtr"))
+            using (var buildDb = new LiteDatabase(Path.Combine(MainPath, "DataManifest.dtr")))
             {
                 buildDb
                   .GetCollection<ResourceManifest>()
@@ -181,29 +181,14 @@ namespace Dungeon
 
         private static MethodInfo GetCollectionMethod => typeof(LiteDatabase).GetMethods().Where(x => x.IsGenericMethod && x.Name == "GetCollection").Last();
 
-        public static string ProjectDirectory
-        {
-            get
-            {
-                try
-                {
-                    return Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory).Parent.Parent.Parent.ToString();
-                }
-                catch (Exception)
-                {
-                    return "";
-                }
-            }
-        }
-
         private static IEnumerable<DataInfo> JsonFiles()
         {
-            IEnumerable<string> databaseDirectories = Directory.GetDirectories(ProjectDirectory,"Database", SearchOption.AllDirectories);
+            IEnumerable<string> databaseDirectories = Directory.GetDirectories(DungeonGlobal.ProjectPath, "Database", SearchOption.AllDirectories);
 
             databaseDirectories = databaseDirectories
                 .Where(x =>
-                    x != Path.Combine(ProjectDirectory, "bin")
-                    && x != Path.Combine(ProjectDirectory, "obj"));
+                    x != Path.Combine(DungeonGlobal.ProjectPath, "bin")
+                    && x != Path.Combine(DungeonGlobal.ProjectPath, "obj"));
 
             return databaseDirectories.SelectMany(databaseDirectory =>
             {
@@ -247,7 +232,7 @@ namespace Dungeon
         {
             ResourceManifest lastBuild = new ResourceManifest();
 
-            using (var buildDb = new LiteDatabase($@"{MainPath}\DataManifest.dtr"))
+            using (var buildDb = new LiteDatabase(Path.Combine(MainPath, "DataManifest.dtr")))
             {
                 lastBuild = buildDb
                     .GetCollection<ResourceManifest>()

--- a/Dungeon/Data/Store.cs
+++ b/Dungeon/Data/Store.cs
@@ -5,6 +5,7 @@
     using Dungeon.Types;
     using LiteDB;
     using System;
+    using System.IO;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
@@ -12,8 +13,8 @@
 
     public static partial class Store
     {
-        public static string MainPath = $@"{AppDomain.CurrentDomain.BaseDirectory}";
-
+        public static string MainPath = DungeonGlobal.BuildLocation;
+        
         public static T EntitySingle<T>(string id, object cacheObject = default, string db = "Data")
             where T : IPersist
         {
@@ -117,7 +118,7 @@
             //if (!Directory.Exists(MainPath))
             //    Directory.CreateDirectory(MainPath);
 
-            using (var db = new LiteDatabase($@"{MainPath}\{dbName}.db"))
+            using (var db = new LiteDatabase(Path.Combine(MainPath, $"{dbName}.db")))
             {
                 var collection = db.GetCollection<T>();
 

--- a/Dungeon/Dungeon.csproj
+++ b/Dungeon/Dungeon.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <Configurations>Debug;Release;CompileDatabase</Configurations>
-    <RestoreFallbackFolders>clear</RestoreFallbackFolders>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Dungeon/Global/DungeonGlobal.cs
+++ b/Dungeon/Global/DungeonGlobal.cs
@@ -103,6 +103,8 @@
         public static Assembly GameAssembly { get; set; }
 
         public static string BuildLocation { get; set; }
+        
+        public static string ProjectPath { get; set; }
 
         private static string _gameTitle;
         public static string GameTitle

--- a/Dungeon/Localization/LocalizationStringDictionary.cs
+++ b/Dungeon/Localization/LocalizationStringDictionary.cs
@@ -28,7 +28,7 @@ namespace Dungeon.Localization
 
         protected string DoPath(string lang)
         {
-            var root = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            var root = DungeonGlobal.BuildLocation;
             var path = Path.Combine(root, ___RelativeLocalizationFilesPath, lang + ".json");
 
             var dir = Path.GetDirectoryName(path);

--- a/Dungeon/Resources/ResourceCompiler.cs
+++ b/Dungeon/Resources/ResourceCompiler.cs
@@ -61,12 +61,7 @@ namespace Dungeon.Resources
             db = litedb.GetCollection<Resource>();
             db.EnsureIndex("Path");
             
-            IEnumerable<string> resDirectories = Directory.GetDirectories(Path.Combine(DungeonGlobal.ProjectPath, "Resources"), "*", SearchOption.AllDirectories);
-            foreach (var resDir in resDirectories)
-            {
-                ProcessProject(resDir, rebuild);
-            }
-
+            ProcessProjectResources(rebuild);
             WriteCurrentBuild();
         }
 
@@ -77,10 +72,9 @@ namespace Dungeon.Resources
             File.WriteAllText(ManifestPath, manifest);
         }
 
-        private void ProcessProject(string projectResDirectory, bool rebuild)
+        private void ProcessProjectResources(bool rebuild)
         {
-            var dir = new DirectoryInfo(projectResDirectory);
-            foreach (var file in Directory.GetFiles(dir.FullName, "*.*", SearchOption.TopDirectoryOnly))
+            foreach (var file in Directory.GetFiles(Path.Combine(DungeonGlobal.ProjectPath, "Resources"), "*.*", SearchOption.AllDirectories))
             {
                 try
                 {

--- a/Dungeon/Resources/ResourceCompiler.cs
+++ b/Dungeon/Resources/ResourceCompiler.cs
@@ -38,13 +38,13 @@ namespace Dungeon.Resources
         public void Compile(bool rebuild=false)
         {
             var caller = Assembly.GetCallingAssembly().GetName().Name;
-            var dir = $@"{MainPath}\Data";
+            var dir = Path.Combine(MainPath, "Data");
             if(!Directory.Exists(dir))
             {
                 Directory.CreateDirectory(dir);
             }
 
-            var path = $@"{dir}\{caller}.dtr";
+            var path = Path.Combine(dir, $"{caller}.dtr");
             if (rebuild && File.Exists(path))
             {
                 File.Delete(path);
@@ -60,8 +60,8 @@ namespace Dungeon.Resources
             
             db = litedb.GetCollection<Resource>();
             db.EnsureIndex("Path");
-
-            IEnumerable<string> resDirectories = Directory.GetDirectories(Store.ProjectDirectory, "Resources", SearchOption.AllDirectories);
+            
+            IEnumerable<string> resDirectories = Directory.GetDirectories(Path.Combine(DungeonGlobal.ProjectPath, "Resources"), "*", SearchOption.AllDirectories);
             foreach (var resDir in resDirectories)
             {
                 ProcessProject(resDir, rebuild);
@@ -72,20 +72,19 @@ namespace Dungeon.Resources
 
         private void WriteCurrentBuild()
         {
-            var manifestPath = $@"{MainPath}\ResourceManifest.dtr";
             var manifest =  JsonConvert.SerializeObject(CurrentBuild, Formatting.Indented);
 
-            File.WriteAllText(manifestPath, manifest);
+            File.WriteAllText(ManifestPath, manifest);
         }
 
         private void ProcessProject(string projectResDirectory, bool rebuild)
         {
             var dir = new DirectoryInfo(projectResDirectory);
-            foreach (var file in Directory.GetFiles(dir.FullName, "*.*", SearchOption.AllDirectories))
+            foreach (var file in Directory.GetFiles(dir.FullName, "*.*", SearchOption.TopDirectoryOnly))
             {
                 try
                 {
-                    ProcessFile(file, GetProjectName(dir)?.Replace(".csproj", ""));
+                    ProcessFile(file);
                 }
                 catch (Exception ex)
                 {
@@ -95,43 +94,28 @@ namespace Dungeon.Resources
             }
         }
 
-        private string GetProjectName(DirectoryInfo directory)
+        private void ProcessFile(string filePath)
         {
-            var proj = directory.GetFiles("*.csproj").FirstOrDefault();
-            if (proj != default)
-            {
-                return proj.Name;
-            }
-            else if (directory.Parent != default)
-            {
-                return GetProjectName(directory.Parent);
-            }
+            var relativePath = FormatPathForDB(filePath);
+            var lastTime = File.GetLastWriteTime(filePath);
+            var res = LastBuild.Resources.FirstOrDefault(x => x.Path == relativePath);
 
-            return null;
-        }
-
-        private void ProcessFile(string file, string projectName)
-        {
-            var path = GetPathUntillProjectName(file, projectName);
-            var lastTime = File.GetLastWriteTime(file);
-            var res = LastBuild.Resources.FirstOrDefault(x => x.Path == path);
-
-            CurrentBuild.Resources.Add(new Resource() { Path = path, LastWriteTime = lastTime });
+            CurrentBuild.Resources.Add(new Resource() { Path = relativePath, LastWriteTime = lastTime });
 
             if(log)
-            Console.WriteLine($"file {file} {(res==default ? "not" : "")} exists");
+            Console.WriteLine($"file {filePath} {(res==default ? "not" : "")} exists");
 
             if (res == default)
             {
                 if (log)
-                    Console.WriteLine($"compiling {file}");
-                CompileNewResource(file, projectName, db, lastTime);
+                    Console.WriteLine($"compiling {filePath}");
+                CompileNewResource(filePath, db, lastTime);
             }
             else
             {
                 if (log)
-                    Console.WriteLine($"check update {file}");
-                CheckUpdateNeeded(file, db, lastTime, res);
+                    Console.WriteLine($"check update {filePath}");
+                CheckUpdateNeeded(filePath, db, lastTime, res);
                 LastBuild.Resources.Remove(res);
             }
         }
@@ -154,45 +138,33 @@ namespace Dungeon.Resources
             db.Update(dataResource);
         }
 
-        private static void CompileNewResource(string file, string projectName, ILiteCollection<Resource> db, DateTime lastTime)
+        private static void CompileNewResource(string filePath, ILiteCollection<Resource> db, DateTime lastTime)
         {
             var newResource = new Resource()
             {
-                Path = GetPathUntillProjectName(file, projectName),// file.Substring(file.IndexOf(projectName + "\\")).Replace("\\", "."),
+                Path = FormatPathForDB(filePath),
                 LastWriteTime = lastTime,
-                Data = File.ReadAllBytes(file)
+                Data = File.ReadAllBytes(filePath)
             };
             db.Insert(newResource);
         }
 
-        public static string GetPathUntillProjectName(string path, string projName)
+        public static string FormatPathForDB(string filePath)
         {
-            var parts = path.Split("\\", StringSplitOptions.RemoveEmptyEntries).Reverse();
-            var partsEnum = parts.GetEnumerator();
-            partsEnum.MoveNext();
-            string currentPart = partsEnum.Current;
-            string newPath = default;
-            while(currentPart!=projName)
-            {
-                newPath = currentPart + (newPath == default ? "" : ".") + newPath;
-                partsEnum.MoveNext();
-                currentPart = partsEnum.Current;
-            }
-
-            return $"{projName}.{newPath}";
+            return Path.GetRelativePath(Directory.GetParent(DungeonGlobal.ProjectPath).ToString(), filePath).Replace(Path.DirectorySeparatorChar, '.');
         }
 
         public static string MainPath => Store.MainPath;
 
-        public static string CompilePath => $@"{MainPath}\Data\{DungeonGlobal.GameAssembly.GetName().Name}.dtr";
+        public static string CompilePath => Path.Combine(MainPath, "Data", $"{DungeonGlobal.GameAssembly.GetName().Name}.dtr");
 
+        public static string ManifestPath = Path.Combine(MainPath, "ResourceManifest.dtr");
+        
         private ResourceManifest GetLastResourceManifestBuild()
         {
-            var manifestPath = $@"{MainPath}\ResourceManifest.dtr";
-
-            if (File.Exists(manifestPath))
+            if (File.Exists(ManifestPath))
             {
-                return JsonConvert.DeserializeObject<ResourceManifest>(File.ReadAllText(manifestPath));
+                return JsonConvert.DeserializeObject<ResourceManifest>(File.ReadAllText(ManifestPath));
             }
 
             return new ResourceManifest();

--- a/Dungeon12/Global.cs
+++ b/Dungeon12/Global.cs
@@ -1,4 +1,6 @@
-﻿using Dungeon;
+﻿using System.Reflection;
+using System.IO;
+using Dungeon;
 using Dungeon.Localization;
 using Dungeon12.Localization;
 
@@ -9,7 +11,8 @@ namespace Dungeon12
         public Global()
         {
             DefaultFontName = "Montserrat";
-            BuildLocation = @"C:\Users\anete\source\repos\Dungeon12\SidusXII\bin\Debug\netcoreapp3.1";
+            BuildLocation = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            ProjectPath = Directory.GetParent(BuildLocation).Parent.Parent.ToString();
         }
 
         public static GameStrings Strings { get; set; } = new GameStrings();


### PR DESCRIPTION
**Changes:**
1. Удалил `<RestoreFallbackFolders>clear</RestoreFallbackFolders>` из пары `.csproj`файлов, на маке это вызывало ошибку, т.к. я понимаю папок `clear` нет в репозитории
2. Обновил `Dungeon12/Global.cs` чтобы переиспользовать пути к основным папкам, я заметил что в разных файлах составляются пути к одним и тем же папкам
3. Пофиксил пути чтобы работали кросс платформенно. Я думаю что я не все пофиксил, пофиксил только те что не позволяли игре запуститься у меня на маке. Я проверил на винде также, всё запускается.
4. Пофиксил 1 баг который нашел из-за которого ты сохранял файл `Dungeon12/Extensions/Resources/ResourcesExtensions.cs` в БД, что на сколько я понимаю нежелательно. Смотри коммент в коде ниже