### PR TITLE
Used ITooltipedDrawText for SlideButton

### DIFF
--- a/Dungeon12/SceneObjects/Stats/SlideButton.cs
+++ b/Dungeon12/SceneObjects/Stats/SlideButton.cs
@@ -1,26 +1,27 @@
 ﻿using Dungeon.Control;
-using Dungeon.SceneObjects;
 using Dungeon12.ECS.Components;
-using System;
+using Dungeon;
+using Dungeon.View.Interfaces;
 
 namespace Dungeon12.SceneObjects.Stats
 {
-    internal class SlideButton : EmptySceneControl, ITooltiped
+    internal class SlideButton : EmptySceneControl, ITooltipedDrawText
     {
         private string img;
         Action _click;
 
-        public SlideButton(Action click, bool left = true)
+        public SlideButton(string tooltipText, Action click, bool left = true)
         {
             img = left ? "left" : "right";
-            this.Width=50;
-            this.Height=50;
+            Width=50;
+            Height=50;
             _click = click;
-
-            this.Image=$"UI/Windows/Stats/{img}.png";
+            Image = $"UI/Windows/Stats/{img}.png";
+            TooltipText = Global.Strings[tooltipText].AsDrawText().Gabriela();;
         }
 
-        public string TooltipText { get; set; }
+        public IDrawText TooltipText { get; }
+        public bool ShowTooltip => true;
 
         public override void Click(PointerArgs args)
         {

--- a/Dungeon12/SceneObjects/Stats/StatsWindow.cs
+++ b/Dungeon12/SceneObjects/Stats/StatsWindow.cs
@@ -7,7 +7,6 @@ using Dungeon.View.Interfaces;
 using Dungeon12.Entities;
 using Dungeon12.Entities.Enums;
 using Dungeon12.SceneObjects.Base;
-using System.Collections.Generic;
 
 namespace Dungeon12.SceneObjects.Stats
 {
@@ -53,8 +52,8 @@ namespace Dungeon12.SceneObjects.Stats
 
             Fill(Component);
 
-            this.AddChild(new SlideButton(SlideBack) { Left=243, Top=25, TooltipText=Global.Strings["Назад"] });
-            this.AddChild(new SlideButton(SlideForward, false) { Left=723, Top=25, TooltipText=Global.Strings["Далее"] });
+            this.AddChild(new SlideButton("Назад", SlideBack) { Left=243, Top=25 });
+            this.AddChild(new SlideButton("Далее", SlideForward, false) { Left=723, Top=25 });
 
             this.AddChild(new Close29x29(this)
             {


### PR DESCRIPTION
ITooltipedDrawText allows you to flexibly change the fonts for displaying text, in addition we unify the way the localization is transferred for different elements.